### PR TITLE
Getting property name without throw/catch exceptions

### DIFF
--- a/src/ReactiveValidation/Helpers/ReactiveValidationHelper.cs
+++ b/src/ReactiveValidation/Helpers/ReactiveValidationHelper.cs
@@ -6,6 +6,12 @@ namespace ReactiveValidation.Helpers
 {
     public static class ReactiveValidationHelper
     {
+        /// <summary>
+        /// Get property info by property name
+        /// </summary>
+        /// <param name="type">Type which contain property</param>
+        /// <param name="propertyName">Property name</param>
+        /// <returns>Property info or exception if property not exist</returns>
         internal static PropertyInfo GetPropertyInfo(Type type, string propertyName)
         {
             const BindingFlags bindingAttributes = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
@@ -17,6 +23,12 @@ namespace ReactiveValidation.Helpers
             return propertyInfo;
         }
 
+        /// <summary>
+        /// Get property info from lambda expression
+        /// </summary>
+        /// <param name="type">Type which contain property</param>
+        /// <param name="expression">Lambda expression</param>
+        /// <returns>Property info or exception if expression is not a property</returns>
         internal static PropertyInfo GetPropertyInfo(Type type, LambdaExpression expression)
         {
             var member = expression.Body as MemberExpression;
@@ -30,22 +42,38 @@ namespace ReactiveValidation.Helpers
             if (type != propInfo.ReflectedType && (propInfo.ReflectedType == null || type.IsSubclassOf(propInfo.ReflectedType) == false))
                 throw new ArgumentException($"Expression '{expression}' refers to a property that is not from type {type}.");
 
-
             return propInfo;
         }
 
-
+        /// <summary>
+        /// Get property name from lambda expression
+        /// </summary>
+        /// <param name="type">Type which contain property</param>
+        /// <param name="expression">Lambda expression</param>
+        /// <returns>Property name or null if expression is not a property</returns>
         internal static string GetPropertyName(Type type, LambdaExpression expression)
         {
-            try {
-                var propertyInfo = GetPropertyInfo(type, expression);
-                return propertyInfo.Name;
-            }
-            catch (ArgumentException) {
+            var member = expression.Body as MemberExpression;
+            if (member == null)
                 return null;
-            }
+
+            var propInfo = member.Member as PropertyInfo;
+            if (propInfo == null)
+                return null;
+
+            if (type != propInfo.ReflectedType && (propInfo.ReflectedType == null || type.IsSubclassOf(propInfo.ReflectedType) == false))
+                return null;
+
+            return propInfo.Name;
         }
 
+
+        /// <summary>
+        /// Get property type by property name
+        /// </summary>
+        /// <param name="type">Type which contain property</param>
+        /// <param name="propertyName">Property name</param>
+        /// <returns>Property type or exception if property not exist</returns>
         internal static Type GetPropertyType(Type type, string propertyName)
         {
             var propertyInfo = GetPropertyInfo(type, propertyName);
@@ -53,6 +81,13 @@ namespace ReactiveValidation.Helpers
             return propertyInfo?.PropertyType;
         }
 
+        /// <summary>
+        /// Get property value from instance by property name
+        /// </summary>
+        /// <typeparam name="TProp">Property type</typeparam>
+        /// <param name="instance">Instance</param>
+        /// <param name="propertyName">Property name</param>
+        /// <returns>Property type or exception if property not exist or cannot cast to type</returns>
         internal static TProp GetPropertyValue<TProp>(object instance, string propertyName)
         {
             var propertyInfo = GetPropertyInfo(instance.GetType(), propertyName);
@@ -60,13 +95,14 @@ namespace ReactiveValidation.Helpers
             return (TProp)propertyInfo.GetValue(instance);
         }
 
-        internal static TParam GetParamFuncValue<TParam>(object instance, Func<object, TParam> paramFunc)
-        {
-            var paramValue = paramFunc.Invoke(instance);
-            return paramValue;
-        }
 
-
+        /// <summary>
+        /// Get additional information about parameter for property validators
+        /// </summary>
+        /// <typeparam name="TObject">Type of instance</typeparam>
+        /// <typeparam name="TParam">Type of parameter</typeparam>
+        /// <param name="paramExpression">Expression which contain parameter</param>
+        /// <returns>Property name (if parameter is property), display name source (if exists) and compiled function</returns>
         public static ParameterInfo<TObject, TParam> GetParameterInfo<TObject, TParam>(this Expression<Func<TObject, TParam>> paramExpression)
             where TObject : IValidatableObject
         {


### PR DESCRIPTION
In property validators often trying get property name from expression. If expression not a property then method throw exception which catching above. There are two problem:
* Exceptions is not fast
* Sometimes exception info appear in Output window

Problem solved by duplicating code getting property info
Connected with #6 