### PR TITLE
28 - Added throttle for properties

### DIFF
--- a/src/ReactiveValidation.Avalonia.Samples/6. Async validation/AsyncValidationViewModel.cs
+++ b/src/ReactiveValidation.Avalonia.Samples/6. Async validation/AsyncValidationViewModel.cs
@@ -54,6 +54,8 @@ namespace ReactiveValidation.Avalonia.Samples._6._Async_validation
                 .NotEmpty()
                 .When(vm => vm.Email, email => string.IsNullOrEmpty(email))
                 .Matches(@"^\d{11}$")
+                // For async validation is good idea to use Throttle.
+                // See ThrottleViewModel.
                 .Must(CheckPhoneIsInUseAsync).WithMessage("Phone number is already using");
 
             builder.RuleFor(vm => vm.Email)
@@ -62,6 +64,8 @@ namespace ReactiveValidation.Avalonia.Samples._6._Async_validation
                 .NotEmpty()
                 .When(vm => vm.PhoneNumber, phoneNumber => string.IsNullOrEmpty(phoneNumber))
                 .Must(IsValidEmail)
+                // For async validation is good idea to use Throttle.
+                // See ThrottleViewModel.
                 .Must(CheckEmailIsInUseAsync).WithMessage("Email is already using");
 
             return builder.Build(this);

--- a/src/ReactiveValidation.Avalonia.Samples/7. Throttle/ThrottleView.axaml
+++ b/src/ReactiveValidation.Avalonia.Samples/7. Throttle/ThrottleView.axaml
@@ -2,14 +2,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:local="clr-namespace:ReactiveValidation.Avalonia.Samples._6._Async_validation"
+             xmlns:local="clr-namespace:ReactiveValidation.Avalonia.Samples._7._Throttle"
              xmlns:s="clr-namespace:ReactiveValidation.Avalonia.Samples"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-             x:Class="ReactiveValidation.Avalonia.Samples._6._Async_validation.AsyncValidationView"
-             x:DataType="local:AsyncValidationViewModel"
+             x:Class="ReactiveValidation.Avalonia.Samples._7._Throttle.ThrottleView"
+             x:DataType="local:ThrottleViewModel"
              x:CompileBindings="True">
     <Design.DataContext>
-        <local:AsyncValidationViewModel />
+        <local:ThrottleViewModel />
     </Design.DataContext>
 
     <Grid>
@@ -21,6 +21,7 @@
 
         <Grid Grid.Column="0">
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -41,19 +42,23 @@
             <TextBox Grid.Row="1" Grid.Column="1"
                      Text="{Binding PhoneNumber, Mode=TwoWay}" />
             <TextBlock Grid.Row="1" Grid.Column="2" Margin="3" MaxWidth="200" TextWrapping="Wrap"
-                       Text="Phone number required if email is not specified.
-&#x0a;Must contains 11 digits.
-&#x0a;If '11111111111' then it is not valid (async check)." />
+                       Text="Phone number required and must contains 11 digits.
+&#x0a;Delay between validating - 2000 ms" />
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Margin="3" Text="Email: " />
-            <TextBox Grid.Row="2" Grid.Column="1"
-                     Text="{Binding Email, Mode=TwoWay}" />
+            <CheckBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+                      Content="I want to specify additional information"
+                      IsChecked="{Binding IsEmailEnabled, Mode=TwoWay}" />
             <TextBlock Grid.Row="2" Grid.Column="2" Margin="3" MaxWidth="200" TextWrapping="Wrap"
-                       Text="Email required if phone number is not specified.
-&#x0a;Expected format - 'xxx@yyy.zz'.
-&#x0a;If 'foo@bar.com' then is not valid (async check)." />
-
-
+                       Text="Email validating only when checked.
+&#x0a;Delay before email validating after this value changed is 3000 ms" />
+            
+            <TextBlock Grid.Row="3" Grid.Column="0" Margin="3" Text="Email: " />
+            <TextBox Grid.Row="3" Grid.Column="1"
+                     IsEnabled="{Binding IsEmailEnabled}"
+                     Text="{Binding Email, Mode=TwoWay}" />
+            <TextBlock Grid.Row="3" Grid.Column="2" Margin="3" MaxWidth="200" TextWrapping="Wrap"
+                       Text="Expected format - 'xxx@yyy.zz'.
+&#x0a;If not empty then delay before validating is 1000 ms" />
         </Grid>
 
         <GridSplitter Grid.Column="1" Width="5" VerticalAlignment="Stretch" HorizontalAlignment="Center" />

--- a/src/ReactiveValidation.Avalonia.Samples/7. Throttle/ThrottleView.axaml.cs
+++ b/src/ReactiveValidation.Avalonia.Samples/7. Throttle/ThrottleView.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace ReactiveValidation.Avalonia.Samples._7._Throttle;
+
+public partial class ThrottleView : UserControl
+{
+    public ThrottleView()
+    {
+        DataContext = new ThrottleViewModel();
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/ReactiveValidation.Avalonia.Samples/7. Throttle/ThrottleViewModel.cs
+++ b/src/ReactiveValidation.Avalonia.Samples/7. Throttle/ThrottleViewModel.cs
@@ -1,0 +1,78 @@
+﻿using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using ReactiveValidation.Extensions;
+
+namespace ReactiveValidation.Avalonia.Samples._7._Throttle
+{
+    /// <summary>
+    /// </summary>
+    public class ThrottleViewModel : ReactiveValidatableObject
+    {
+        /// <inheritdoc />
+        public ThrottleViewModel()
+        {
+            Validator = GetValidator();
+            WaitValidatingCompletedCommand = ReactiveCommand.CreateFromTask(WaitValidatingCompletedAsync);
+        }
+
+        
+        [Reactive]
+        public string? PhoneNumber { get; set; }
+
+        [Reactive]
+        public bool IsEmailEnabled { get; set; }
+        
+        [Reactive]
+        public string? Email { get; set; }
+
+        public ICommand WaitValidatingCompletedCommand { get; }
+
+        private async Task WaitValidatingCompletedAsync()
+        {
+            if (Validator == null)
+                return;
+            
+            await Validator.WaitValidatingCompletedAsync();
+            
+            var dialog = MessageBox.Avalonia.MessageBoxManager
+                    .GetMessageBoxStandardWindow("", "Async validation has completed");
+            await dialog.Show();
+        }
+        
+        private IObjectValidator GetValidator()
+        {
+            var builder = new ValidationBuilder<ThrottleViewModel>();
+
+            builder.RuleFor(vm => vm.PhoneNumber)
+                .NotEmpty()
+                .Matches(@"^\d{11}$")
+                .CommonThrottle(2000);
+
+            builder.RuleFor(vm => vm.Email)
+                .NotEmpty()
+                .Must(IsValidEmail)
+                    .Throttle(1000)
+                .AllWhen(vm => vm.IsEmailEnabled)
+                .CommonThrottle(throttleBuilder => throttleBuilder
+                    .AddRelatedPropertyThrottle(vm => vm.IsEmailEnabled, 3000));
+
+            return builder.Build(this);
+        }
+        
+
+        /// <summary>
+        /// Check of email is valid.
+        /// </summary>
+        private static bool IsValidEmail(string? email)
+        {
+            if (string.IsNullOrEmpty(email))
+                return true;
+
+            return Regex.IsMatch(email, @"^\w+@\w+\.\w+$");
+        }
+    }
+}

--- a/src/ReactiveValidation.Avalonia.Samples/MainWindow.axaml
+++ b/src/ReactiveValidation.Avalonia.Samples/MainWindow.axaml
@@ -9,6 +9,7 @@
         xmlns:ivoac="clr-namespace:ReactiveValidation.Avalonia.Samples._4._Inner_validatable_object_and_collection"
         xmlns:vbf="clr-namespace:ReactiveValidation.Avalonia.Samples._5._Validation_builder_factory"
         xmlns:av="clr-namespace:ReactiveValidation.Avalonia.Samples._6._Async_validation"
+        xmlns:throttle="clr-namespace:ReactiveValidation.Avalonia.Samples._7._Throttle"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="ReactiveValidation.Avalonia.Samples.Views.MainWindow"
         Icon="/Assets/avalonia-logo.ico"
@@ -38,6 +39,10 @@
             
             <TabItem Padding="3" Header="6. Async validation">
                 <av:AsyncValidationView />
+            </TabItem>
+            
+            <TabItem Padding="3" Header="7. Throttle">
+                <throttle:ThrottleView />
             </TabItem>
         </TabControl>
     </Grid>

--- a/src/ReactiveValidation.Avalonia.Samples/ReactiveValidation.Avalonia.Samples.csproj
+++ b/src/ReactiveValidation.Avalonia.Samples/ReactiveValidation.Avalonia.Samples.csproj
@@ -66,6 +66,10 @@
         <AutoGen>True</AutoGen>
         <DependentUpon>Additional.resx</DependentUpon>
       </Compile>
+      <Compile Update="7. Throttle\ThrottleView.axaml.cs">
+        <DependentUpon>AsyncValidationView.axaml</DependentUpon>
+        <SubType>Code</SubType>
+      </Compile>
     </ItemGroup>
     <ItemGroup>
       <EmbeddedResource Update="Resources\Additional.cs.resx">

--- a/src/ReactiveValidation.Tests/Helpers/ValidationContextFactoryExtensions.cs
+++ b/src/ReactiveValidation.Tests/Helpers/ValidationContextFactoryExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using ReactiveValidation.Tests.TestModels;
+using ReactiveValidation.ValidatorFactory;
+using ReactiveValidation.Validators;
+
+namespace ReactiveValidation.Tests.Helpers
+{
+    /// <summary>
+    /// Extensions for <see cref="ValidationContextFactory{TObject}" />.
+    /// </summary>
+    internal static class ValidationContextFactoryExtensions
+    {
+        /// <summary>
+        /// Create test object of <see cref="ValidationContextFactory{TObject}" />.
+        /// </summary>
+        public static ValidationContextFactory<TestValidatableObject> CreateValidationContextFactory(
+            string propertyName, object? value)
+        {
+            return new ValidationContextFactory<TestValidatableObject>(
+                new TestValidatableObject(),
+                new ValidationContextCache(),
+                new Dictionary<string, PropertyChangedStopwatch>(),
+                propertyName,
+                null,
+                value);
+        }
+    }
+}

--- a/src/ReactiveValidation.Tests/Validators/BetweenValidatorTests.cs
+++ b/src/ReactiveValidation.Tests/Validators/BetweenValidatorTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 
 using Moq;
@@ -68,24 +67,6 @@ namespace ReactiveValidation.Tests.Validators
             AssertValidationMessage.EmptyMessage(validationMessage);
         }
 
-        private ValidationMessage? Between<TProp>(
-            TProp value,
-            TProp from,
-            TProp to,
-            IComparer? comparer = null,
-            ValidationMessageType validationMessageType = ValidationMessageType.Error)
-                where TProp : IComparable<TProp>
-        {
-            var betweenValidator = new BetweenValidator<TestValidatableObject, TProp>(_ => from, _ => to, comparer, validationMessageType);
-            var factory = new ValidationContextFactory<TestValidatableObject>(null, new ValidationContextCache(), nameof(TestValidatableObject.Number), null, value);
-            var validationMessage = betweenValidator.ValidateProperty(factory).SingleOrDefault();
-
-            return validationMessage;
-        }
-
-
-
-
         [Fact]
         public void BetweenExtensions_Between20And10_Exception()
         {
@@ -94,6 +75,21 @@ namespace ReactiveValidation.Tests.Validators
 
             var ruleBuilder = Mock.Of<ISinglePropertyRuleBuilder<TestValidatableObject, int>>();
             Assert.Throws<ArgumentException>(() => ruleBuilder.Between(from, to));
+        }
+
+        private static ValidationMessage? Between<TProp>(
+            TProp value,
+            TProp from,
+            TProp to,
+            IComparer? comparer = null,
+            ValidationMessageType validationMessageType = ValidationMessageType.Error)
+            where TProp : IComparable<TProp>
+        {
+            var betweenValidator = new BetweenValidator<TestValidatableObject, TProp>(_ => from, _ => to, comparer, validationMessageType);
+            var factory = ValidationContextFactoryExtensions.CreateValidationContextFactory(nameof(TestValidatableObject.Number), value);
+            var validationMessage = betweenValidator.ValidateProperty(factory).SingleOrDefault();
+
+            return validationMessage;
         }
     }
 }

--- a/src/ReactiveValidation.Tests/Validators/EqualValidatorTests.cs
+++ b/src/ReactiveValidation.Tests/Validators/EqualValidatorTests.cs
@@ -42,14 +42,14 @@ namespace ReactiveValidation.Tests.Validators
         }
 
 
-        private ValidationMessage Equal<TProp>(
+        private static ValidationMessage? Equal<TProp>(
             TProp value,
             TProp valueToCompare,
-            IEqualityComparer comparer = null,
+            IEqualityComparer? comparer = null,
             ValidationMessageType validationMessageType = ValidationMessageType.Error)
         {
             var equalValidator = new EqualValidator<TestValidatableObject, TProp>(_ => valueToCompare, comparer, validationMessageType);
-            var factory = new ValidationContextFactory<TestValidatableObject>(null, new ValidationContextCache(), nameof(TestValidatableObject.Number), null, value);
+            var factory = ValidationContextFactoryExtensions.CreateValidationContextFactory(nameof(TestValidatableObject.Number), value);
             var validationMessage = equalValidator.ValidateProperty(factory).FirstOrDefault();
 
             return validationMessage;

--- a/src/ReactiveValidation.Tests/Validators/GreaterThanOrEqualToValidatorTests.cs
+++ b/src/ReactiveValidation.Tests/Validators/GreaterThanOrEqualToValidatorTests.cs
@@ -62,15 +62,15 @@ namespace ReactiveValidation.Tests.Validators
         }
 
 
-        private ValidationMessage GreaterThanOrEqualTo<TProp>(
+        private static ValidationMessage? GreaterThanOrEqualTo<TProp>(
             TProp value,
             TProp valueToCompare,
-            IComparer comparer = null,
+            IComparer? comparer = null,
             ValidationMessageType validationMessageType = ValidationMessageType.Error)
                 where TProp : IComparable<TProp>
         {
             var greaterThanOrEqualToValidator = new GreaterThanOrEqualValidator<TestValidatableObject, TProp>(_ => valueToCompare, comparer, validationMessageType);
-            var factory = new ValidationContextFactory<TestValidatableObject>(null, new ValidationContextCache(), nameof(TestValidatableObject.Number), null, value);
+            var factory = ValidationContextFactoryExtensions.CreateValidationContextFactory(nameof(TestValidatableObject.Number), value);
             var validationMessage = greaterThanOrEqualToValidator.ValidateProperty(factory).FirstOrDefault();
 
             return validationMessage;

--- a/src/ReactiveValidation.Tests/Validators/GreaterThanValidatorTests.cs
+++ b/src/ReactiveValidation.Tests/Validators/GreaterThanValidatorTests.cs
@@ -55,15 +55,15 @@ namespace ReactiveValidation.Tests.Validators
         }
 
 
-        private ValidationMessage GreaterThan<TProp>(
+        private static ValidationMessage? GreaterThan<TProp>(
             TProp value,
             TProp valueToCompare,
-            IComparer comparer = null,
+            IComparer? comparer = null,
             ValidationMessageType validationMessageType = ValidationMessageType.Error)
                 where TProp : IComparable<TProp>
         {
             var greaterThanValidator = new GreaterThanValidator<TestValidatableObject, TProp>(_ => valueToCompare, comparer, validationMessageType);
-            var factory = new ValidationContextFactory<TestValidatableObject>(null, new ValidationContextCache(), nameof(TestValidatableObject.Number), null, value);
+            var factory = ValidationContextFactoryExtensions.CreateValidationContextFactory(nameof(TestValidatableObject.Number), value);
             var validationMessage = greaterThanValidator.ValidateProperty(factory).FirstOrDefault();
 
             return validationMessage;

--- a/src/ReactiveValidation.Tests/Validators/LengthValidatorsTests.cs
+++ b/src/ReactiveValidation.Tests/Validators/LengthValidatorsTests.cs
@@ -33,14 +33,14 @@ namespace ReactiveValidation.Tests.Validators
             AssertValidationMessage.NotEmptyMessage(validationMessage);
         }
 
-        private ValidationMessage BetweenLength(
+        private static ValidationMessage? BetweenLength(
             string value,
             int minLength,
             int maxLength,
             ValidationMessageType validationMessageType = ValidationMessageType.Error)
         {
             var betweenLengthValidator = new LengthValidator<TestValidatableObject>(_ => minLength, _ => maxLength, validationMessageType);
-            var factory = new ValidationContextFactory<TestValidatableObject>(null, new ValidationContextCache(), nameof(TestValidatableObject.Number), null, value);
+            var factory = ValidationContextFactoryExtensions.CreateValidationContextFactory(nameof(TestValidatableObject.Number), value);
             var validationMessage = betweenLengthValidator.ValidateProperty(factory).FirstOrDefault();
 
             return validationMessage;
@@ -71,13 +71,13 @@ namespace ReactiveValidation.Tests.Validators
             AssertValidationMessage.NotEmptyMessage(validationMessage);
         }
 
-        private ValidationMessage MinLength(
+        private static ValidationMessage? MinLength(
             string value,
             int minLength,
             ValidationMessageType validationMessageType = ValidationMessageType.Error)
         {
             var betweenLengthValidator = new MinLengthValidator<TestValidatableObject>(_ => minLength, validationMessageType);
-            var factory = new ValidationContextFactory<TestValidatableObject>(null, new ValidationContextCache(), nameof(TestValidatableObject.Number), null, value);
+            var factory = ValidationContextFactoryExtensions.CreateValidationContextFactory(nameof(TestValidatableObject.Number), value);
             var validationMessage = betweenLengthValidator.ValidateProperty(factory).FirstOrDefault();
 
             return validationMessage;
@@ -108,13 +108,13 @@ namespace ReactiveValidation.Tests.Validators
             AssertValidationMessage.NotEmptyMessage(validationMessage);
         }
 
-        private ValidationMessage MaxLength(
+        private static ValidationMessage? MaxLength(
             string value,
             int maxLength,
             ValidationMessageType validationMessageType = ValidationMessageType.Error)
         {
             var betweenLengthValidator = new MaxLengthValidator<TestValidatableObject>(_ => maxLength, validationMessageType);
-            var factory = new ValidationContextFactory<TestValidatableObject>(null, new ValidationContextCache(), nameof(TestValidatableObject.Number), null, value);
+            var factory = ValidationContextFactoryExtensions.CreateValidationContextFactory(nameof(TestValidatableObject.Number), value);
             var validationMessage = betweenLengthValidator.ValidateProperty(factory).FirstOrDefault();
 
             return validationMessage;
@@ -147,13 +147,13 @@ namespace ReactiveValidation.Tests.Validators
             AssertValidationMessage.NotEmptyMessage(validationMessage);
         }
 
-        private ValidationMessage ExactLength(
+        private static ValidationMessage? ExactLength(
             string value,
             int length,
             ValidationMessageType validationMessageType = ValidationMessageType.Error)
         {
             var betweenLengthValidator = new ExactLengthValidator<TestValidatableObject>(_ => length, validationMessageType);
-            var factory = new ValidationContextFactory<TestValidatableObject>(null, new ValidationContextCache(), nameof(TestValidatableObject.Number), null, value);
+            var factory = ValidationContextFactoryExtensions.CreateValidationContextFactory(nameof(TestValidatableObject.Number), value);
             var validationMessage = betweenLengthValidator.ValidateProperty(factory).FirstOrDefault();
 
             return validationMessage;

--- a/src/ReactiveValidation.Tests/Validators/LessThanOrEqualToValidatorTests.cs
+++ b/src/ReactiveValidation.Tests/Validators/LessThanOrEqualToValidatorTests.cs
@@ -62,15 +62,15 @@ namespace ReactiveValidation.Tests.Validators
         }
 
 
-        private ValidationMessage LessThanOrEqualTo<TProp>(
+        private static ValidationMessage? LessThanOrEqualTo<TProp>(
             TProp value,
             TProp valueToCompare,
-            IComparer comparer = null,
+            IComparer? comparer = null,
             ValidationMessageType validationMessageType = ValidationMessageType.Error)
                 where TProp : IComparable<TProp>
         {
             var lessThanOrEqualToValidator = new LessThanOrEqualValidator<TestValidatableObject, TProp>(_ => valueToCompare, comparer, validationMessageType);
-            var factory = new ValidationContextFactory<TestValidatableObject>(null, new ValidationContextCache(), nameof(TestValidatableObject.Number), null, value);
+            var factory = ValidationContextFactoryExtensions.CreateValidationContextFactory(nameof(TestValidatableObject.Number), value);
             var validationMessage = lessThanOrEqualToValidator.ValidateProperty(factory).FirstOrDefault();
 
             return validationMessage;

--- a/src/ReactiveValidation.Tests/Validators/LessThanValidatorTests.cs
+++ b/src/ReactiveValidation.Tests/Validators/LessThanValidatorTests.cs
@@ -55,15 +55,15 @@ namespace ReactiveValidation.Tests.Validators
         }
 
 
-        private ValidationMessage LessThan<TProp>(
+        private static ValidationMessage? LessThan<TProp>(
             TProp value,
             TProp valueToCompare,
-            IComparer comparer = null,
+            IComparer? comparer = null,
             ValidationMessageType validationMessageType = ValidationMessageType.Error)
                 where TProp : IComparable<TProp>
         {
             var lessThanValidator = new LessThanValidator<TestValidatableObject, TProp>(_ => valueToCompare, comparer, validationMessageType);
-            var factory = new ValidationContextFactory<TestValidatableObject>(null, new ValidationContextCache(), nameof(TestValidatableObject.Number), null, value);
+            var factory = ValidationContextFactoryExtensions.CreateValidationContextFactory(nameof(TestValidatableObject.Number), value);
             var validationMessage = lessThanValidator.ValidateProperty(factory).FirstOrDefault();
 
             return validationMessage;

--- a/src/ReactiveValidation.Tests/Validators/RegularExpressionValidatorTests.cs
+++ b/src/ReactiveValidation.Tests/Validators/RegularExpressionValidatorTests.cs
@@ -16,7 +16,7 @@ namespace ReactiveValidation.Tests.Validators
         public void RegularExpressionValidator_ValidTheory(string s, string pattern)
         {
             var lessThanOrEqualToValidator = new RegularExpressionValidator<TestValidatableObject>(_ => pattern, ValidationMessageType.Error);
-            var factory = new ValidationContextFactory<TestValidatableObject>(null, new ValidationContextCache(), nameof(TestValidatableObject.Number), null, s);
+            var factory = ValidationContextFactoryExtensions.CreateValidationContextFactory(nameof(TestValidatableObject.Number), s);
             var validationMessage = lessThanOrEqualToValidator.ValidateProperty(factory).FirstOrDefault();
 
             AssertValidationMessage.EmptyMessage(validationMessage);
@@ -28,7 +28,7 @@ namespace ReactiveValidation.Tests.Validators
         public void RegularExpressionValidator_NotValidTheory(string s, string pattern)
         {
             var lessThanOrEqualToValidator = new RegularExpressionValidator<TestValidatableObject>(_ => pattern, ValidationMessageType.Error);
-            var factory = new ValidationContextFactory<TestValidatableObject>(null, new ValidationContextCache(), nameof(TestValidatableObject.Number), null, s);
+            var factory = ValidationContextFactoryExtensions.CreateValidationContextFactory(nameof(TestValidatableObject.Number), s);
             var validationMessage = lessThanOrEqualToValidator.ValidateProperty(factory).FirstOrDefault();
 
             AssertValidationMessage.NotEmptyMessage(validationMessage);

--- a/src/ReactiveValidation.Wpf.Samples/6. Async validation/AsyncValidationViewModel.cs
+++ b/src/ReactiveValidation.Wpf.Samples/6. Async validation/AsyncValidationViewModel.cs
@@ -52,6 +52,8 @@ namespace ReactiveValidation.Wpf.Samples._6._Async_validation
                 .NotEmpty()
                 .When(vm => vm.Email, email => string.IsNullOrEmpty(email))
                 .Matches(@"^\d{11}$")
+                // For async validation is good idea to use Throttle.
+                // See ThrottleViewModel.
                 .Must(CheckPhoneIsInUseAsync).WithMessage("Phone number is already using");
 
             builder.RuleFor(vm => vm.Email)
@@ -60,6 +62,8 @@ namespace ReactiveValidation.Wpf.Samples._6._Async_validation
                 .NotEmpty()
                 .When(vm => vm.PhoneNumber, phoneNumber => string.IsNullOrEmpty(phoneNumber))
                 .Must(IsValidEmail)
+                // For async validation is good idea to use Throttle.
+                // See ThrottleViewModel.
                 .Must(CheckEmailIsInUseAsync).WithMessage("Email is already using");
 
             return builder.Build(this);

--- a/src/ReactiveValidation.Wpf.Samples/7. Throttle/ThrottleView.xaml
+++ b/src/ReactiveValidation.Wpf.Samples/7. Throttle/ThrottleView.xaml
@@ -1,0 +1,82 @@
+﻿<UserControl x:Class="ReactiveValidation.Wpf.Samples._7._Throttle.ThrottleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ReactiveValidation.Wpf.Samples._7._Throttle"
+             xmlns:s="clr-namespace:ReactiveValidation.Wpf.Samples"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800"
+             d:DataContext="{d:DesignInstance local:ThrottleViewModel}">
+    <UserControl.Resources>
+        <!-- It is more convenient to create a base style for control.  -->
+        <Style x:Key="TextBox" TargetType="TextBox">
+            <Setter Property="Validation.ErrorTemplate" Value="{StaticResource ExtendedErrorTemplate}" />
+
+            <Setter Property="Margin" Value="3" />
+        </Style>
+        
+        <Style x:Key="CheckBox" TargetType="CheckBox">
+            <Setter Property="Validation.ErrorTemplate" Value="{StaticResource ExtendedErrorTemplate}" />
+
+            <Setter Property="Margin" Value="3" />
+        </Style>
+    </UserControl.Resources>
+
+    <AdornerDecorator>
+         <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Grid Grid.Column="0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <Button Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" HorizontalAlignment="Left"
+                        Margin="3" Padding="6,3,6,3"
+                        Content="Wait async validation completed"
+                        Command="{Binding WaitValidatingCompletedCommand}"/>
+
+                <TextBlock Grid.Row="1" Grid.Column="0" Margin="3" Text="Phone number: " />
+                <TextBox Grid.Row="1" Grid.Column="1" Style="{StaticResource TextBox}"
+                         Text="{Binding PhoneNumber, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <TextBlock Grid.Row="1" Grid.Column="2" Margin="3" MaxWidth="200" TextWrapping="Wrap"
+                           Text="Phone number required and must contains 11 digits.
+&#x0a;Delay between validating - 2000 ms" />
+
+                <CheckBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Style="{StaticResource CheckBox}"
+                          Content="I want to specify additional information"
+                          IsChecked="{Binding IsEmailEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <TextBlock Grid.Row="2" Grid.Column="2" Margin="3" MaxWidth="200" TextWrapping="Wrap"
+                           Text="Email validating only when checked.
+&#x0a;Delay before email validating after this value changed is 3000 ms" />
+
+                <TextBlock Grid.Row="3" Grid.Column="0" Margin="3" Text="Email: " />
+                <TextBox Grid.Row="3" Grid.Column="1" Style="{StaticResource TextBox}"
+                         IsEnabled="{Binding IsEmailEnabled}"
+                         Text="{Binding Email, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <TextBlock Grid.Row="3" Grid.Column="2" Margin="3" MaxWidth="200" TextWrapping="Wrap"
+                           Text="Expected format - 'xxx@yyy.zz'.
+&#x0a;If not empty then delay before validating is 1000 ms" />
+
+            </Grid>
+
+            <GridSplitter Grid.Column="1" Width="5" VerticalAlignment="Stretch" HorizontalAlignment="Center" />
+
+            <s:ValidationStateInfoControl Grid.Column="2" DataContext="{Binding Validator}" />
+        </Grid>   
+    </AdornerDecorator>
+</UserControl>

--- a/src/ReactiveValidation.Wpf.Samples/7. Throttle/ThrottleView.xaml.cs
+++ b/src/ReactiveValidation.Wpf.Samples/7. Throttle/ThrottleView.xaml.cs
@@ -1,0 +1,14 @@
+﻿using System.Windows.Controls;
+
+namespace ReactiveValidation.Wpf.Samples._7._Throttle
+{
+    public partial class ThrottleView : UserControl
+    {
+        public ThrottleView()
+        {
+            DataContext = new ThrottleViewModel();
+
+            InitializeComponent();
+        }
+    }
+}

--- a/src/ReactiveValidation.Wpf.Samples/7. Throttle/ThrottleViewModel.cs
+++ b/src/ReactiveValidation.Wpf.Samples/7. Throttle/ThrottleViewModel.cs
@@ -1,0 +1,76 @@
+﻿using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using ReactiveValidation.Extensions;
+
+namespace ReactiveValidation.Wpf.Samples._7._Throttle
+{
+    /// <summary>
+    /// </summary>
+    public class ThrottleViewModel : ReactiveValidatableObject
+    {
+        /// <inheritdoc />
+        public ThrottleViewModel()
+        {
+            Validator = GetValidator();
+            WaitValidatingCompletedCommand = ReactiveCommand.CreateFromTask(WaitValidatingCompletedAsync);
+        }
+
+
+        [Reactive]
+        public string? PhoneNumber { get; set; }
+
+        [Reactive]
+        public bool IsEmailEnabled { get; set; }
+
+        [Reactive]
+        public string? Email { get; set; }
+
+        public ICommand WaitValidatingCompletedCommand { get; }
+
+        private async Task WaitValidatingCompletedAsync()
+        {
+            if (Validator == null)
+                return;
+
+            await Validator.WaitValidatingCompletedAsync();
+            MessageBox.Show("Async validation has completed");
+        }
+        
+        private IObjectValidator GetValidator()
+        {
+            var builder = new ValidationBuilder<ThrottleViewModel>();
+
+            builder.RuleFor(vm => vm.PhoneNumber)
+                .NotEmpty()
+                .Matches(@"^\d{11}$")
+                .CommonThrottle(2000);
+
+            builder.RuleFor(vm => vm.Email)
+                .NotEmpty()
+                .Must(IsValidEmail)
+                    .Throttle(1000)
+                .AllWhen(vm => vm.IsEmailEnabled)
+                .CommonThrottle(throttleBuilder => throttleBuilder
+                    .AddRelatedPropertyThrottle(vm => vm.IsEmailEnabled, 3000));
+
+            return builder.Build(this);
+        }
+        
+
+        /// <summary>
+        /// Check of email is valid.
+        /// </summary>
+        private static bool IsValidEmail(string? email)
+        {
+            if (string.IsNullOrEmpty(email))
+                return true;
+
+            return Regex.IsMatch(email, @"^\w+@\w+\.\w+$");
+        }
+    }
+}

--- a/src/ReactiveValidation.Wpf.Samples/MainWindow.xaml
+++ b/src/ReactiveValidation.Wpf.Samples/MainWindow.xaml
@@ -10,6 +10,7 @@
         xmlns:ivoac="clr-namespace:ReactiveValidation.Wpf.Samples._4._Inner_validatable_object_and_collection"
         xmlns:vbf="clr-namespace:ReactiveValidation.Wpf.Samples._5._Validation_builder_factory"
         xmlns:av="clr-namespace:ReactiveValidation.Wpf.Samples._6._Async_validation"
+        xmlns:throttle="clr-namespace:ReactiveValidation.Wpf.Samples._7._Throttle"
         mc:Ignorable="d"
         Title="ReactiveValidation samples" Height="500" Width="1000">
     <Grid>
@@ -36,6 +37,10 @@
             
             <TabItem Padding="3" Header="6. Async validation">
                 <av:AsyncValidationView />
+            </TabItem>
+            
+            <TabItem Padding="3" Header="7. Throttle">
+                <throttle:ThrottleView />
             </TabItem>
         </TabControl>
     </Grid>

--- a/src/ReactiveValidation.Wpf.Samples/ReactiveValidation.Wpf.Samples.csproj
+++ b/src/ReactiveValidation.Wpf.Samples/ReactiveValidation.Wpf.Samples.csproj
@@ -75,4 +75,11 @@
       <Version>18.3.1</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup>
+    <Page Update="7. Throttle\ThrottleView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <XamlRuntime>Wpf</XamlRuntime>
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
 </Project>

--- a/src/ReactiveValidation/Extensions/ThrottleExtensions.cs
+++ b/src/ReactiveValidation/Extensions/ThrottleExtensions.cs
@@ -1,0 +1,116 @@
+using System;
+using ReactiveValidation.Validators.Throttle;
+
+namespace ReactiveValidation.Extensions;
+
+/// <summary>
+/// Extensions for throttle settings.
+/// </summary>
+public static class ThrottleExtensions
+{
+    /// <summary>
+    /// Property will begin validating after <paramref name="validatingPropertyMillisecondsDelay" />.
+    /// If property changes value while this delay, previous value won't be validated.
+    /// </summary>
+    /// <param name="ruleBuilder">The rule builder on which the validator should be defined.</param>
+    /// <param name="validatingPropertyMillisecondsDelay">The duration in milliseconds of the throttle period for validating property.</param>
+    /// <typeparam name="TNext">The type of the next rule builder.</typeparam>
+    /// <typeparam name="TObject">The type of validatable object.</typeparam>
+    /// <typeparam name="TProp">The type of validatable property.</typeparam>
+    public static TNext Throttle<TObject, TProp, TNext>(
+        this IRuleBuilder<TObject, TProp, TNext> ruleBuilder,
+        int validatingPropertyMillisecondsDelay)
+        where TNext : IRuleBuilder<TObject, TProp, TNext>
+        where TObject : IValidatableObject
+    {
+        return ruleBuilder.Throttle(builder => builder.AddValidatingPropertyThrottle(validatingPropertyMillisecondsDelay));
+    }
+    
+    /// <summary>
+    /// Property will begin validating after <paramref name="validatingPropertyMillisecondsDelay" />.
+    /// If property changes value while this delay, previous value won't be validated.
+    /// </summary>
+    /// <param name="ruleBuilder">The rule builder on which the validator should be defined.</param>
+    /// <param name="validatingPropertyMillisecondsDelay">The duration in milliseconds of the throttle period for validating property.</param>
+    /// <typeparam name="TObject">The type of validatable object.</typeparam>
+    /// <typeparam name="TProp">The type of validatable property.</typeparam>
+    public static IRuleBuilderOption<TObject, TProp> CommonThrottle<TObject, TProp>(
+        this IRuleBuilderOption<TObject, TProp> ruleBuilder,
+        int validatingPropertyMillisecondsDelay)
+        where TObject : IValidatableObject
+    {
+        return ruleBuilder.CommonThrottle(builder => builder.AddValidatingPropertyThrottle(validatingPropertyMillisecondsDelay));
+    }
+
+    /// <summary>
+    /// Property will begin validating after <paramref name="validatingPropertyDueTime" />.
+    /// If property changes value while this delay, previous value won't be validated.
+    /// </summary>
+    /// <param name="ruleBuilder">The rule builder on which the validator should be defined.</param>
+    /// <param name="validatingPropertyDueTime">The duration of the throttle period for validating property.</param>
+    /// <typeparam name="TNext">The type of the next rule builder.</typeparam>
+    /// <typeparam name="TObject">The type of validatable object.</typeparam>
+    /// <typeparam name="TProp">The type of validatable property.</typeparam>
+    public static TNext Throttle<TObject, TProp, TNext>(
+        this IRuleBuilder<TObject, TProp, TNext> ruleBuilder,
+        TimeSpan validatingPropertyDueTime)
+        where TNext : IRuleBuilder<TObject, TProp, TNext>
+        where TObject : IValidatableObject
+    {
+        return ruleBuilder.Throttle(builder => builder.AddValidatingPropertyThrottle(validatingPropertyDueTime));
+    }
+
+    /// <summary>
+    /// Property will begin validating after <paramref name="validatingPropertyDueTime" />.
+    /// If property changes value while this delay, previous value won't be validated.
+    /// </summary>
+    /// <param name="ruleBuilder">The rule builder on which the validator should be defined.</param>
+    /// <param name="validatingPropertyDueTime">The duration of the throttle period for validating property.</param>
+    /// <typeparam name="TObject">The type of validatable object.</typeparam>
+    /// <typeparam name="TProp">The type of validatable property.</typeparam>
+    public static IRuleBuilderOption<TObject, TProp> CommonThrottle<TObject, TProp>(
+        this IRuleBuilderOption<TObject, TProp> ruleBuilder,
+        TimeSpan validatingPropertyDueTime)
+        where TObject : IValidatableObject
+    {
+        return ruleBuilder.CommonThrottle(builder => builder.AddValidatingPropertyThrottle(validatingPropertyDueTime));
+    }
+
+    /// <summary>
+    /// Property will begin validating after specified by builder delay.
+    /// If property changes value while this delay, previous value won't be validated.
+    /// </summary>
+    /// <param name="ruleBuilder">The rule builder on which the validator should be defined.</param>
+    /// <param name="propertiesThrottleBuilderAction">Action for building properties' throttle.</param>
+    /// <typeparam name="TNext">The type of the next rule builder.</typeparam>
+    /// <typeparam name="TObject">The type of validatable object.</typeparam>
+    /// <typeparam name="TProp">The type of validatable property.</typeparam>
+    public static TNext Throttle<TObject, TProp, TNext>(
+        this IRuleBuilder<TObject, TProp, TNext> ruleBuilder,
+        Action<PropertiesThrottleBuilder<TObject>> propertiesThrottleBuilderAction)
+        where TNext : IRuleBuilder<TObject, TProp, TNext>
+        where TObject : IValidatableObject
+    {
+        var builder = new PropertiesThrottleBuilder<TObject>();
+        propertiesThrottleBuilderAction.Invoke(builder);
+        return ruleBuilder.Throttle(builder.Build());
+    }
+
+    /// <summary>
+    /// Property will begin validating after specified by builder delay.
+    /// If property changes value while this delay, previous value won't be validated.
+    /// </summary>
+    /// <param name="ruleBuilder">The rule builder on which the validator should be defined.</param>
+    /// <param name="propertiesThrottleBuilderAction">Action for building properties' throttle.</param>
+    /// <typeparam name="TObject">The type of validatable object.</typeparam>
+    /// <typeparam name="TProp">The type of validatable property.</typeparam>
+    public static IRuleBuilderOption<TObject, TProp> CommonThrottle<TObject, TProp>(
+        this IRuleBuilderOption<TObject, TProp> ruleBuilder,
+        Action<PropertiesThrottleBuilder<TObject>> propertiesThrottleBuilderAction)
+        where TObject : IValidatableObject
+    {
+        var builder = new PropertiesThrottleBuilder<TObject>();
+        propertiesThrottleBuilderAction.Invoke(builder);
+        return ruleBuilder.CommonThrottle(builder.Build());
+    }
+}

--- a/src/ReactiveValidation/RuleBuilders/IRuleBuilder.cs
+++ b/src/ReactiveValidation/RuleBuilders/IRuleBuilder.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq.Expressions;
 using ReactiveValidation.ObjectObserver;
 using ReactiveValidation.Resources.StringSources;
 using ReactiveValidation.Validators;
 using ReactiveValidation.Validators.Conditions;
+using ReactiveValidation.Validators.Throttle;
 
 namespace ReactiveValidation
 {
@@ -60,6 +59,12 @@ namespace ReactiveValidation
         /// </summary>
         /// <param name="stringSource">Validation message source.</param>
         TBuilder WithMessageSource(IStringSource stringSource);
+
+        /// <summary>
+        /// Allows to setup delay before property validation execution.
+        /// If property changes value while this delay, previous value won't be validated.
+        /// </summary>
+        TBuilder Throttle(IPropertiesThrottle propertiesThrottle);
     }
 
 

--- a/src/ReactiveValidation/RuleBuilders/IRuleBuilderOption.cs
+++ b/src/ReactiveValidation/RuleBuilders/IRuleBuilderOption.cs
@@ -1,5 +1,5 @@
-﻿using ReactiveValidation.Validators;
-using ReactiveValidation.Validators.Conditions;
+﻿using ReactiveValidation.Validators.Conditions;
+using ReactiveValidation.Validators.Throttle;
 
 namespace ReactiveValidation
 {
@@ -15,5 +15,11 @@ namespace ReactiveValidation
         /// The validation of the rule will occur only if the condition is <see langword="true" />.
         /// </summary>
         IRuleBuilderOption<TObject, TProp> AllWhen(IValidationCondition<TObject> validationCondition);
+
+        /// <summary>
+        /// Allows to setup delay before property validation execution.
+        /// If property changes value while this delay, previous value won't be validated.
+        /// </summary>
+        IRuleBuilderOption<TObject, TProp> CommonThrottle(IPropertiesThrottle propertiesThrottle);
     }
 }

--- a/src/ReactiveValidation/RuleBuilders/RuleBuilder.cs
+++ b/src/ReactiveValidation/RuleBuilders/RuleBuilder.cs
@@ -61,7 +61,7 @@ namespace ReactiveValidation
                 return _propertyValidators;
 
             return _propertyValidators
-                .Select(pv => new WrappingValidator<TObject, TProp>(_commonCondition, _valueTransformer, _commonThrottle, pv))
+                .Select(pv => new WrappingValidator<TObject, TProp>(pv, _commonCondition, _valueTransformer, _commonThrottle))
                 .ToList();
         }
 

--- a/src/ReactiveValidation/RuleBuilders/RuleBuilder.cs
+++ b/src/ReactiveValidation/RuleBuilders/RuleBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using ReactiveValidation.Extensions;
 using ReactiveValidation.ObjectObserver;
@@ -6,6 +7,7 @@ using ReactiveValidation.Resources.StringSources;
 using ReactiveValidation.Validators;
 using ReactiveValidation.Validators.Conditions;
 using ReactiveValidation.Validators.PropertyValueTransformers;
+using ReactiveValidation.Validators.Throttle;
 
 namespace ReactiveValidation
 {
@@ -26,6 +28,7 @@ namespace ReactiveValidation
 
         private IPropertyValidator<TObject>? _currentValidator;
         private IValidationCondition<TObject>? _commonCondition;
+        private IPropertiesThrottle? _commonThrottle;
 
         /// <summary>
         /// Create new base rule builder instance.
@@ -54,17 +57,20 @@ namespace ReactiveValidation
         /// <inheritdoc />
         public IReadOnlyList<IPropertyValidator<TObject>> GetValidators()
         {
-            if (_commonCondition == null && _valueTransformer == null)
+            if (_commonCondition == null && _valueTransformer == null && _commonThrottle == null)
                 return _propertyValidators;
 
             return _propertyValidators
-                .Select(pv => new WrappingValidator<TObject, TProp>(_commonCondition, _valueTransformer, pv))
+                .Select(pv => new WrappingValidator<TObject, TProp>(_commonCondition, _valueTransformer, _commonThrottle, pv))
                 .ToList();
         }
 
         /// <inheritdoc />
         public TBuilder SetValidator(IPropertyValidator<TObject> validator)
         {
+            if (validator == null)
+                throw new ArgumentNullException(nameof(validator));
+
             _propertyValidators.Add(validator);
             _currentValidator = validator;
 
@@ -75,6 +81,9 @@ namespace ReactiveValidation
         /// <inheritdoc />
         public TBuilder When(IValidationCondition<TObject> condition)
         {
+            if (condition == null)
+                throw new ArgumentNullException(nameof(condition));
+
             _currentValidator.GuardNotNull("Current validator hasn't set");
             _currentValidator.ValidateWhen(condition);
 
@@ -84,6 +93,9 @@ namespace ReactiveValidation
         /// <inheritdoc />
         public TBuilder WithMessageSource(IStringSource stringSource)
         {
+            if (stringSource == null)
+                throw new ArgumentNullException(nameof(stringSource));
+
             _currentValidator.GuardNotNull("Current validator hasn't set");
             _currentValidator.SetStringSource(stringSource);
 
@@ -91,15 +103,42 @@ namespace ReactiveValidation
         }
 
         /// <inheritdoc />
+        public TBuilder Throttle(IPropertiesThrottle propertiesThrottle)
+        {
+            if (propertiesThrottle == null)
+                throw new ArgumentNullException(nameof(propertiesThrottle));
+
+            _currentValidator.GuardNotNull("Current validator hasn't set");
+            _currentValidator.Throttle(propertiesThrottle);
+
+            return This;
+        }
+
+        /// <inheritdoc />
         public IRuleBuilderOption<TObject, TProp> AllWhen(IValidationCondition<TObject> validationCondition)
         {
-            _commonCondition.GuardNotCallTwice("Method 'AllWhen' already have been called");
+            if (validationCondition == null)
+                throw new ArgumentNullException(nameof(validationCondition));
+
+            _commonCondition.GuardNotCallTwice("Method 'AllWhen' has already been called");
             _commonCondition = validationCondition;
 
             return This;
         }
 
-        
+        /// <inheritdoc />
+        public IRuleBuilderOption<TObject, TProp> CommonThrottle(IPropertiesThrottle propertiesThrottle)
+        {
+            if (propertiesThrottle == null)
+                throw new ArgumentNullException(nameof(propertiesThrottle));
+
+            _commonThrottle.GuardNotCallTwice("Method 'CommonThrottle' has already been called");
+            _commonThrottle = propertiesThrottle;
+
+            return This;
+        }
+
+
         /// <summary>
         /// Reference to strong-typed current object.
         /// </summary>

--- a/src/ReactiveValidation/ValidatorFactory/PropertyChangedStopwatch.cs
+++ b/src/ReactiveValidation/ValidatorFactory/PropertyChangedStopwatch.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ReactiveValidation.ValidatorFactory
+{
+    /// <summary>
+    /// Stopwatch for property changed event.
+    /// </summary>
+    public class PropertyChangedStopwatch
+    {
+        private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+
+        /// <summary>
+        /// Create instance of <see cref="PropertyChangedStopwatch" /> class.
+        /// </summary>
+        internal PropertyChangedStopwatch()
+        {
+        }
+
+        /// <summary>
+        /// Wait until <paramref name="dueTime" /> have passed since the last property change.
+        /// </summary>
+        public Task WaitUntilAsync(TimeSpan dueTime, CancellationToken cancellationToken)
+        {
+            var elapsed = _stopwatch.Elapsed;
+            if (elapsed >= dueTime)
+                return Task.CompletedTask;
+
+            return Task.Delay(dueTime - elapsed, cancellationToken);
+        }
+
+        /// <summary>
+        /// Restart stopwatch.
+        /// </summary>
+        internal PropertyChangedStopwatch Restart()
+        {
+            _stopwatch.Restart();
+            return this;
+        }
+    }
+}

--- a/src/ReactiveValidation/Validators/Base/BaseAsyncPropertyValidator.cs
+++ b/src/ReactiveValidation/Validators/Base/BaseAsyncPropertyValidator.cs
@@ -30,7 +30,7 @@ namespace ReactiveValidation.Validators
         }
 
         /// <inheritdoc />
-        public override bool IsAsync => true;
+        public sealed override bool IsAsync => true;
 
         /// <inheritdoc />
         public sealed override IReadOnlyList<ValidationMessage> ValidateProperty(ValidationContextFactory<TObject> contextFactory)
@@ -43,9 +43,12 @@ namespace ReactiveValidation.Validators
         {
             if (CheckIgnoreValidation(contextFactory))
                 return Array.Empty<ValidationMessage>();
-            
+
+            if (HasThrottle)
+                await ThrottleAsync(contextFactory, cancellationToken).ConfigureAwait(false);
+
             var context = contextFactory.CreateContext<TProp>();
-            if (await IsValidAsync(context, cancellationToken))
+            if (await IsValidAsync(context, cancellationToken).ConfigureAwait(false))
                 return Array.Empty<ValidationMessage>();
 
             return GetValidationMessages(context);

--- a/src/ReactiveValidation/Validators/Base/BasePropertyValidator.cs
+++ b/src/ReactiveValidation/Validators/Base/BasePropertyValidator.cs
@@ -57,14 +57,14 @@ namespace ReactiveValidation.Validators
         /// <inheritdoc />
         public void SetStringSource(IStringSource stringSource)
         {
-            _overriddenStringSource.GuardNotCallTwice($"Methods 'WithMessage'/'WithLocalizedMessage' already have been called for {this.GetType()}");
+            _overriddenStringSource.GuardNotCallTwice($"Methods 'WithMessage'/'WithLocalizedMessage' already has been called for {this.GetType()}");
             _overriddenStringSource = stringSource;
         }
 
         /// <inheritdoc />
         public void ValidateWhen(IValidationCondition<TObject> condition)
         {
-            _condition.GuardNotCallTwice($"Method 'When' already have been called for {this.GetType()}");
+            _condition.GuardNotCallTwice($"Method 'When' already has been called for {this.GetType()}");
             _condition = condition;
 
             RelatedProperties = GetUnionRelatedProperties(condition.RelatedProperties);
@@ -73,7 +73,7 @@ namespace ReactiveValidation.Validators
         /// <inheritdoc />
         public void Throttle(IPropertiesThrottle propertiesThrottle)
         {
-            _throttle.GuardNotCallTwice($"Method 'When' already have been called for {this.GetType()}");
+            _throttle.GuardNotCallTwice($"Method 'Throttle' already has been called for {this.GetType()}");
             _throttle = propertiesThrottle;
         }
 

--- a/src/ReactiveValidation/Validators/Base/BasePropertyValidator.cs
+++ b/src/ReactiveValidation/Validators/Base/BasePropertyValidator.cs
@@ -8,6 +8,7 @@ using ReactiveValidation.Extensions;
 using ReactiveValidation.Helpers;
 using ReactiveValidation.Resources.StringSources;
 using ReactiveValidation.Validators.Conditions;
+using ReactiveValidation.Validators.Throttle;
 
 namespace ReactiveValidation.Validators
 {
@@ -24,6 +25,7 @@ namespace ReactiveValidation.Validators
 
         private IValidationCondition<TObject>? _condition;
         private IStringSource? _overriddenStringSource;
+        private IPropertiesThrottle? _throttle;
 
         /// <summary>
         /// Create new validator for property value.
@@ -46,7 +48,12 @@ namespace ReactiveValidation.Validators
         /// <inheritdoc />
         public IReadOnlyList<string> RelatedProperties { get; private set; }
 
-        
+        /// <summary>
+        /// Check if validator has throttle.
+        /// </summary>
+        protected bool HasThrottle => _throttle != null;
+
+
         /// <inheritdoc />
         public void SetStringSource(IStringSource stringSource)
         {
@@ -61,6 +68,13 @@ namespace ReactiveValidation.Validators
             _condition = condition;
 
             RelatedProperties = GetUnionRelatedProperties(condition.RelatedProperties);
+        }
+
+        /// <inheritdoc />
+        public void Throttle(IPropertiesThrottle propertiesThrottle)
+        {
+            _throttle.GuardNotCallTwice($"Method 'When' already have been called for {this.GetType()}");
+            _throttle = propertiesThrottle;
         }
 
 
@@ -78,7 +92,10 @@ namespace ReactiveValidation.Validators
         /// </summary>
         protected virtual bool CheckIgnoreValidation(ValidationContextFactory<TObject> validationContextFactory)
         {
-            return _condition?.ShouldIgnoreValidation(validationContextFactory) == true;
+            if (_condition != null)
+                validationContextFactory.RegisterValidationCondition(_condition);
+
+            return validationContextFactory.ShouldIgnoreValidation();
         }
 
         /// <summary>
@@ -91,6 +108,16 @@ namespace ReactiveValidation.Validators
             return new []{ validationMessage };
         }
 
+        /// <summary>
+        /// Execute delay because of throttle.
+        /// </summary>
+        protected async Task ThrottleAsync(ValidationContextFactory<TObject> contextFactory, CancellationToken cancellationToken)
+        {
+            if (_throttle != null)
+                contextFactory.RegisterPropertiesThrottle(_throttle);
+
+            await contextFactory.ThrottleAsync(cancellationToken);
+        }
 
         /// <summary>
         /// Get names of related properties.

--- a/src/ReactiveValidation/Validators/Base/IPropertyValidator.cs
+++ b/src/ReactiveValidation/Validators/Base/IPropertyValidator.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ReactiveValidation.Resources.StringSources;
 using ReactiveValidation.Validators.Conditions;
+using ReactiveValidation.Validators.Throttle;
 
 namespace ReactiveValidation.Validators
 {
@@ -57,6 +58,12 @@ namespace ReactiveValidation.Validators
         /// </summary>
         /// <param name="condition">Condition.</param>
         void ValidateWhen(IValidationCondition<TObject> condition);
+
+        /// <summary>
+        /// Allows to setup delay before property validation execution.
+        /// If property changes value while this delay, previous value won't be validated.
+        /// </summary>
+        void Throttle(IPropertiesThrottle propertiesThrottle);
 
         #endregion
     }

--- a/src/ReactiveValidation/Validators/Contexts/AggregatedValidationContext.cs
+++ b/src/ReactiveValidation/Validators/Contexts/AggregatedValidationContext.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using ReactiveValidation.Helpers;
 using ReactiveValidation.Resources.StringSources;
+using ReactiveValidation.ValidatorFactory;
 
 namespace ReactiveValidation.Validators
 {
@@ -14,16 +15,19 @@ namespace ReactiveValidation.Validators
         private readonly TObject _validatableObject;
         private readonly IReadOnlyDictionary<string, IStringSource?> _displayNamesSources;
         private readonly ValidationContextCache _validationContextCache;
+        private readonly IReadOnlyDictionary<string, PropertyChangedStopwatch> _propertyChangedStopwatches;
 
         /// <summary>
         /// Create new aggregated validation context.
         /// </summary>
         /// <param name="validatableObject">Object which being validating.</param>
         /// <param name="displayNamesSources">Sources of display names.</param>
-        public AggregatedValidationContext(TObject validatableObject, IReadOnlyDictionary<string, IStringSource?> displayNamesSources)
+        /// <param name="propertyChangedStopwatches">Stopwatches for property changed event.</param>
+        public AggregatedValidationContext(TObject validatableObject, IReadOnlyDictionary<string, IStringSource?> displayNamesSources, IReadOnlyDictionary<string, PropertyChangedStopwatch> propertyChangedStopwatches)
         {
             _validatableObject = validatableObject;
             _displayNamesSources = displayNamesSources;
+            _propertyChangedStopwatches = propertyChangedStopwatches;
             _validationContextCache = new ValidationContextCache();
         }
 
@@ -32,7 +36,7 @@ namespace ReactiveValidation.Validators
         /// </summary>
         public ValidationContextFactory<TObject> CreateContextFactory(string propertyName)
         {
-            return new ValidationContextFactory<TObject>(_validatableObject, _validationContextCache, propertyName, _displayNamesSources[propertyName], GetPropertyValue(propertyName));
+            return new ValidationContextFactory<TObject>(_validatableObject, _validationContextCache, _propertyChangedStopwatches, propertyName, _displayNamesSources[propertyName], GetPropertyValue(propertyName));
         }
 
         /// <summary>
@@ -47,7 +51,7 @@ namespace ReactiveValidation.Validators
                 propertyValue = ReactiveValidationHelper.GetPropertyValue<object>(_validatableObject, propertyName);
                 _validationContextCache.SetPropertyValue(propertyName, propertyValue);
             }
-            
+
             return propertyValue;
         }
     }

--- a/src/ReactiveValidation/Validators/Throttle/IPropertiesThrottle.cs
+++ b/src/ReactiveValidation/Validators/Throttle/IPropertiesThrottle.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ReactiveValidation.Validators.Throttle;
+
+/// <summary>
+/// Allows to setup delay before property validation execution.
+/// If property changes value while this delay, previous value won't be validated.
+/// </summary>
+public interface IPropertiesThrottle
+{
+    /// <summary>
+    /// Execute delay after property value changed.
+    /// </summary>
+    public Task DelayAsync<TObject>(ValidationContextFactory<TObject> validationContextFactory, CancellationToken cancellationToken)
+        where TObject : IValidatableObject;
+}

--- a/src/ReactiveValidation/Validators/Throttle/PropertiesThrottle.cs
+++ b/src/ReactiveValidation/Validators/Throttle/PropertiesThrottle.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ReactiveValidation.ValidatorFactory;
+
+namespace ReactiveValidation.Validators.Throttle;
+
+/// <inheritdoc />
+public class PropertiesThrottle : IPropertiesThrottle
+{
+    private readonly TimeSpan? _validatingPropertyDueTo;
+    private readonly Dictionary<string, TimeSpan> _relatedPropertiesDueTo;
+
+    /// <summary>
+    /// Create instance of <see cref="PropertiesThrottle" /> class.
+    /// </summary>
+    /// <param name="validatingPropertyDueTo">Delay for target validating property.</param>
+    /// <param name="relatedPropertiesDueTo">Delays for other related properties.</param>
+    public PropertiesThrottle(TimeSpan? validatingPropertyDueTo, Dictionary<string, TimeSpan> relatedPropertiesDueTo)
+    {
+        _validatingPropertyDueTo = validatingPropertyDueTo;
+        _relatedPropertiesDueTo = relatedPropertiesDueTo;
+    }
+
+    /// <inheritdoc />
+    public async Task DelayAsync<TObject>(
+        ValidationContextFactory<TObject> validationContextFactory,
+        CancellationToken cancellationToken)
+        where TObject : IValidatableObject
+    {
+        if (_validatingPropertyDueTo != null)
+        {
+            await DelayPropertyAsync(
+                validationContextFactory.PropertyChangedStopwatches,
+                validationContextFactory.PropertyName,
+                _validatingPropertyDueTo.Value,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        foreach (var relatedProperty in _relatedPropertiesDueTo)
+        {
+            await DelayPropertyAsync(
+                validationContextFactory.PropertyChangedStopwatches,
+                relatedProperty.Key,
+                relatedProperty.Value,
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Execute delay after property value changed.
+    /// </summary>
+    private static Task DelayPropertyAsync(
+        IReadOnlyDictionary<string, PropertyChangedStopwatch> propertyChangedStopwatches,
+        string propertyName,
+        TimeSpan propertyDueTo,
+        CancellationToken cancellationToken)
+    {
+        if (!propertyChangedStopwatches.TryGetValue(propertyName, out var propertyChangedStopwatch))
+            return Task.CompletedTask;
+
+        return propertyChangedStopwatch.WaitUntilAsync(propertyDueTo, cancellationToken);
+    }
+}

--- a/src/ReactiveValidation/Validators/Throttle/PropertiesThrottleBuilder.cs
+++ b/src/ReactiveValidation/Validators/Throttle/PropertiesThrottleBuilder.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using ReactiveValidation.Extensions;
+using ReactiveValidation.Helpers;
+
+namespace ReactiveValidation.Validators.Throttle;
+
+/// <summary>
+/// Builder for <see cref="PropertiesThrottle" />.
+/// </summary>
+public class PropertiesThrottleBuilder<TObject>
+    where TObject : IValidatableObject
+{
+    private TimeSpan? _validatingPropertyDueTo;
+    private readonly Dictionary<string, TimeSpan> _relatedPropertiesDueTo = new();
+
+    /// <summary>
+    /// Property will begin validating after <paramref name="validatingPropertyMillisecondsDelay" />.
+    /// If property changes value while this delay, previous value won't be validated.
+    /// </summary>
+    /// <param name="validatingPropertyMillisecondsDelay">The duration in milliseconds of the throttle period for validating property.</param>
+    public PropertiesThrottleBuilder<TObject> AddValidatingPropertyThrottle(int validatingPropertyMillisecondsDelay)
+    {
+        return AddValidatingPropertyThrottle(TimeSpan.FromMilliseconds(validatingPropertyMillisecondsDelay));
+    }
+
+    /// <summary>
+    /// Property will begin validating after <paramref name="validatingPropertyDueTime" />.
+    /// If property changes value while this delay, previous value won't be validated.
+    /// </summary>
+    /// <param name="validatingPropertyDueTime">The duration of the throttle period for validating property.</param>
+    public PropertiesThrottleBuilder<TObject> AddValidatingPropertyThrottle(TimeSpan validatingPropertyDueTime)
+    {
+        _validatingPropertyDueTo.GuardNotCallTwice("Validating property throttle is already specified");
+        _validatingPropertyDueTo = validatingPropertyDueTime;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Property will begin validating after <paramref name="relatedPropertyMillisecondsDelay" /> from changing <paramref name="property" />.
+    /// If <paramref name="property" /> changes value while this delay, previous value won't be validated.
+    /// </summary>
+    /// <typeparam name="TProp">Type of related property.</typeparam>
+    /// <param name="property">Related property.</param>
+    /// <param name="relatedPropertyMillisecondsDelay">The duration of the throttle period for related property.</param>
+    public PropertiesThrottleBuilder<TObject> AddRelatedPropertyThrottle<TProp>(Expression<Func<TObject, TProp>> property, int relatedPropertyMillisecondsDelay)
+    {
+        return AddRelatedPropertyThrottle(property, TimeSpan.FromMilliseconds(relatedPropertyMillisecondsDelay));
+    }
+
+    /// <summary>
+    /// Property will begin validating after <paramref name="relatedPropertyDueTime" /> from changing <paramref name="property" />.
+    /// If <paramref name="property" /> changes value while this delay, previous value won't be validated.
+    /// </summary>
+    /// <typeparam name="TProp">Type of related property.</typeparam>
+    /// <param name="property">Related property.</param>
+    /// <param name="relatedPropertyDueTime">The duration of the throttle period for related property.</param>
+    public PropertiesThrottleBuilder<TObject> AddRelatedPropertyThrottle<TProp>(Expression<Func<TObject, TProp>> property, TimeSpan relatedPropertyDueTime)
+    {
+        var propertyName = ReactiveValidationHelper
+            .GetPropertyInfo(typeof(TObject), property)
+            .Name;
+        return AddRelatedPropertyThrottle(propertyName, relatedPropertyDueTime);
+    }
+
+    /// <summary>
+    /// Property will begin validating after <paramref name="relatedPropertyMillisecondsDelay" /> from changing <paramref name="propertyName" />.
+    /// If <paramref name="propertyName" /> changes value while this delay, previous value won't be validated.
+    /// </summary>
+    /// <param name="propertyName">The name of related property.</param>
+    /// <param name="relatedPropertyMillisecondsDelay">The duration of the throttle period for related property.</param>
+    public PropertiesThrottleBuilder<TObject> AddRelatedPropertyThrottle(string propertyName, int relatedPropertyMillisecondsDelay)
+    {
+        return AddRelatedPropertyThrottle(propertyName, TimeSpan.FromMilliseconds(relatedPropertyMillisecondsDelay));
+    }
+
+    /// <summary>
+    /// Property will begin validating after <paramref name="relatedPropertyDueTime" /> from changing <paramref name="propertyName" />.
+    /// If <paramref name="propertyName" /> changes value while this delay, previous value won't be validated.
+    /// </summary>
+    /// <param name="propertyName">The name of related property.</param>
+    /// <param name="relatedPropertyDueTime">The duration of the throttle period for related property.</param>
+    public PropertiesThrottleBuilder<TObject> AddRelatedPropertyThrottle(string propertyName, TimeSpan relatedPropertyDueTime)
+    {
+        if (_relatedPropertiesDueTo.ContainsKey(propertyName))
+            throw new ArgumentException($"Throttle for property {propertyName} is already added", nameof(propertyName));
+        
+        _relatedPropertiesDueTo.Add(propertyName, relatedPropertyDueTime);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Create instance of <see cref="IPropertiesThrottle" /> with specified settings.
+    /// </summary>
+    public IPropertiesThrottle Build()
+    {
+        return new PropertiesThrottle(_validatingPropertyDueTo, _relatedPropertiesDueTo);
+    }
+}

--- a/src/ReactiveValidation/Validators/Throttle/PropertiesThrottleBuilder.cs
+++ b/src/ReactiveValidation/Validators/Throttle/PropertiesThrottleBuilder.cs
@@ -85,8 +85,8 @@ public class PropertiesThrottleBuilder<TObject>
     public PropertiesThrottleBuilder<TObject> AddRelatedPropertyThrottle(string propertyName, TimeSpan relatedPropertyDueTime)
     {
         if (_relatedPropertiesDueTo.ContainsKey(propertyName))
-            throw new ArgumentException($"Throttle for property {propertyName} is already added", nameof(propertyName));
-        
+            throw new ArgumentException($"Throttle for property {propertyName} has been already added", nameof(propertyName));
+
         _relatedPropertiesDueTo.Add(propertyName, relatedPropertyDueTime);
 
         return this;

--- a/src/ReactiveValidation/Validators/WrappingValidator.cs
+++ b/src/ReactiveValidation/Validators/WrappingValidator.cs
@@ -25,17 +25,17 @@ namespace ReactiveValidation.Validators
         private readonly IPropertiesThrottle? _throttle;
 
         /// <summary>
-        /// Create new instance of wrapping validator.
+        /// Create instance of <see cref="WrappingValidator{TObject,TProp}" /> class.
         /// </summary>
-        /// <param name="condition">Condition the using inner validator.</param>
-        /// <param name="valueTransformer"></param>
-        /// <param name="throttle">The properties throttle.</param>
         /// <param name="innerValidator">Inner validator.</param>
+        /// <param name="condition">Condition the using inner validator.</param>
+        /// <param name="valueTransformer">Property value transformer.</param>
+        /// <param name="throttle">The properties throttle.</param>
         public WrappingValidator(
-            IValidationCondition<TObject>? condition,
-            IValueTransformer<TObject, TProp>? valueTransformer,
-            IPropertiesThrottle? throttle,
-            IPropertyValidator<TObject> innerValidator)
+            IPropertyValidator<TObject> innerValidator,
+            IValidationCondition<TObject>? condition = null,
+            IValueTransformer<TObject, TProp>? valueTransformer = null,
+            IPropertiesThrottle? throttle = null)
         {
             _condition = condition;
             _valueTransformer = valueTransformer;
@@ -68,7 +68,7 @@ namespace ReactiveValidation.Validators
                 throw new NotSupportedException();
 
             if (_valueTransformer != null)
-                contextFactory = GetTransformedContextFactory(contextFactory, _valueTransformer);
+                contextFactory = contextFactory.GetTransformedContextFactory(_valueTransformer);
 
             if (_condition != null)
                 contextFactory.RegisterValidationCondition(_condition);
@@ -83,7 +83,7 @@ namespace ReactiveValidation.Validators
                 throw new NotSupportedException();
             
             if (_valueTransformer != null)
-                contextFactory = GetTransformedContextFactory(contextFactory, _valueTransformer);
+                contextFactory = contextFactory.GetTransformedContextFactory(_valueTransformer);
             
             if (_condition != null)
                 contextFactory.RegisterValidationCondition(_condition);
@@ -96,19 +96,19 @@ namespace ReactiveValidation.Validators
         /// <inheritdoc />
         public void SetStringSource(IStringSource stringSource)
         {
-            throw new NotSupportedException("Wrapping validator doesn't support settings");
+            throw new NotSupportedException($"{nameof(WrappingValidator<TObject, TProp>)} doesn't support settings");
         }
 
         /// <inheritdoc />
         public void ValidateWhen(IValidationCondition<TObject> condition)
         {
-            throw new NotSupportedException("Wrapping validator doesn't support settings");
+            throw new NotSupportedException($"{nameof(WrappingValidator<TObject, TProp>)} doesn't support settings");
         }
 
         /// <inheritdoc />
         public void Throttle(IPropertiesThrottle propertiesThrottle)
         {
-            throw new NotSupportedException("Wrapping validator doesn't support settings");
+            throw new NotSupportedException($"{nameof(WrappingValidator<TObject, TProp>)} doesn't support settings");
         }
 
         /// <summary>
@@ -130,29 +130,6 @@ namespace ReactiveValidation.Validators
             }
 
             return relatedProperties.ToList();
-        }
-
-        /// <summary>
-        /// Get new context factory with transformed property value.
-        /// </summary>
-        private static ValidationContextFactory<TObject> GetTransformedContextFactory(
-            ValidationContextFactory<TObject> contextFactory,
-            IValueTransformer<TObject, TProp> valueTransformer)
-        {
-            var validationContextCache = contextFactory.ValidationContextCache;
-            if (!validationContextCache.TryGetValue(valueTransformer, out var transformedPropertyValue))
-            {
-                transformedPropertyValue = valueTransformer.Transform(contextFactory.ValidatableObject, contextFactory.PropertyValue);
-                validationContextCache.SetValue(valueTransformer, transformedPropertyValue);
-            }
-
-            return new ValidationContextFactory<TObject>(
-                contextFactory.ValidatableObject,
-                contextFactory.ValidationContextCache,
-                contextFactory.PropertyChangedStopwatches,
-                contextFactory.PropertyName,
-                contextFactory.DisplayNameSource,
-                transformedPropertyValue);
         }
     }
 }


### PR DESCRIPTION
Based on #28 

Added possibility to use `throttle` for sync and async validators (sync validators becomes to async in this case).

Usages:

``` c#
builder.RuleFor(vm => vm.PhoneNumber)
    .NotEmpty()
    .Matches(@"^\d{11}$")
    .CommonThrottle(2000);

builder.RuleFor(vm => vm.Email)
    .NotEmpty()
    .Must(IsValidEmail)
        .Throttle(1000)
    .AllWhen(vm => vm.IsEmailEnabled)
    .CommonThrottle(throttleBuilder => throttleBuilder
        .AddRelatedPropertyThrottle(vm => vm.IsEmailEnabled, 3000));
```

It's possible to set up throttle for each rule and each property.

Also fixed bug with two async validators. If all of them were canceled while the first was executing, then the second one was not ignored.
